### PR TITLE
Fix path to global types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "typeRoots": ["../../../../node_modules/@types"]
   },
-  "files": ["../../../types/global.d.ts"],
+  "files": ["./node_modules/@metamask/snap-types/global.d.ts"],
   "include": ["src"]
 }


### PR DESCRIPTION
Fix path to `global.d.ts` which in turn fixes types for the `wallet` global.